### PR TITLE
使用 postcss-mobile-forever 适配全端，提高可访问性

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -144,15 +144,22 @@ module.exports = function (webpackEnv) {
                   },
                 ],
                 [
-                  'postcss-px-to-viewport',
+                  'postcss-mobile-forever',
                   {
-                    viewportWidth: 375, // (Number) The width of the viewport. 
-                    viewportHeight: 1334, // (Number) The height of the viewport. -- 一般不需要配置 
+                    rootSelector: "#root", // (String) Viewport root.
+                    viewportWidth: 375, // (Number|Function) The width of the viewport. 
+                    maxDisplayWidth: null, // (Number) Limit max width of viewport.
                     unitPrecision: 3, // (Number) The decimal numbers to allow the REM units to grow to. 
-                    viewportUnit: "vw", // (String) Expected units. 
                     selectorBlackList: [], // (Array) The selectors to ignore and leave as px. 
-                    minPixelValue: 1, // (Number) Set the minimum pixel value to replace. 
-                    mediaQuery: false // (Boolean) Allow px to be converted in media queries. 
+                    disableLandscape: false, // (Boolean) Disable to generate landscape viewport.
+                    disableDesktop: false, // (Boolean) Disable to generate desktop viewport.
+                    border: true, // (Boolean|String) The landscape and desktop viewport border.
+                    rootContainingBlockSelectorList: ["rv-tabbar"], // (Array) The filter of root containing-block selector.
+                    mobileConfig: {
+                      viewportUnit: "vw", // (String) Expected units. 
+                      fontViewportUnit: "vw", // (String) Expected font units. 
+                      replace: true, // (Boolean) Replace property.
+                    }
                   }
                 ],
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "postcss-loader": "^7.0.2",
-    "postcss-px-to-viewport": "^1.1.1"
+    "postcss-mobile-forever": "^2.3.3"
   },
   "jest": {
     "roots": [

--- a/src/App.css
+++ b/src/App.css
@@ -5,3 +5,6 @@
 ul{
     list-style: none;
 }
+#root {
+    width: 100%;
+}

--- a/src/views/Mine/index.css
+++ b/src/views/Mine/index.css
@@ -2,6 +2,7 @@
   width: 100%;
   min-height: 100vh;
   background-color: #f1f1f1;
+  position: relative;
 }
 .mine .mineTop {
   width: 100%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6584,7 +6584,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.npmmirror.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-object-assign@>=4.0.1, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -7172,6 +7172,11 @@ postcss-minify-selectors@^5.2.1:
   dependencies:
     postcss-selector-parser "^6.0.5"
 
+postcss-mobile-forever@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/postcss-mobile-forever/-/postcss-mobile-forever-2.3.3.tgz#2280962c0d0f946f59060bcad91dee2ef211791d"
+  integrity sha512-Zch37T6oxypIQcz/SXHZvEeCGC5Grk0dfMCwY3MGEuRGc1syvvzQKIbAyel+r//45EZlsWzs+Zs5TkCQRAVZ7A==
+
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmmirror.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
@@ -7381,14 +7386,6 @@ postcss-pseudo-class-any-link@^7.1.6:
   dependencies:
     postcss-selector-parser "^6.0.10"
 
-postcss-px-to-viewport@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmmirror.com/postcss-px-to-viewport/-/postcss-px-to-viewport-1.1.1.tgz#a25ca410b553c9892cc8b525cc710da47bf1aa55"
-  integrity sha512-2x9oGnBms+e0cYtBJOZdlwrFg/mLR4P1g2IFu7jYKvnqnH/HLhoKyareW2Q/x4sg0BgklHlP1qeWo2oCyPm8FQ==
-  dependencies:
-    object-assign ">=4.0.1"
-    postcss ">=5.0.2"
-
 postcss-reduce-initial@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmmirror.com/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz#798cd77b3e033eae7105c18c9d371d989e1382d6"
@@ -7444,15 +7441,6 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.npmmirror.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@>=5.0.2, postcss@^8.0.9, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.4:
-  version "8.4.21"
-  resolved "https://registry.npmmirror.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
-  integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@^7.0.35:
   version "7.0.39"
   resolved "https://registry.npmmirror.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
@@ -7460,6 +7448,15 @@ postcss@^7.0.35:
   dependencies:
     picocolors "^0.2.1"
     source-map "^0.6.1"
+
+postcss@^8.0.9, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.4:
+  version "8.4.21"
+  resolved "https://registry.npmmirror.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
+  integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
你好啊，欢迎试下我最近开发的适配屏幕插件，[postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)。

这个插件可以适配桌面端和横屏，也可以限制视口单位的最大宽度。另外插件基本支持 px-to-viewport，相关功能通过了单元测试，插件基于 PostCSS 8 开发，所以控制台不报警，另外 viewportWidth 参数支持传递函数，这样可以动态生成视图宽度。

欢迎使用啊，我持续维护，有问题我会及时修复～

下面是我在您项目里运行的结果：

<table>
	<tr>
		<td><img src="https://user-images.githubusercontent.com/26893092/223913519-9ac18e99-7b86-4aee-abfd-1e77565b6d88.PNG" alt="移动端的展示效果" /></td>
		<td><img src="https://user-images.githubusercontent.com/26893092/223913533-09884cbd-dbc9-4472-8f4e-d9dd05bd63ba.PNG" alt="移动端横屏的展示效果" /></td>
	</tr>
	<tr>
		<td colspan="2"><img src="https://user-images.githubusercontent.com/26893092/223913542-d95772ce-e777-42bb-9ca7-bbb8ce324fc5.png" alt="桌面端的展示效果" /></td>
	</tr>
</table>

